### PR TITLE
FIX CHECKPOINT-LEA: ';' NOT NEEDED AFTER LAST VALUE

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -2958,14 +2958,18 @@ PARSER_Parse(CheckpointLEA)
 			++i;
 		} else {
 			iValue = i;
-			while (i < npb->strLen && npb->str[i] != ';') {
+			while (i < npb->strLen && npb->str[i] != ';' && npb->str[i] != data->terminator) {
 				++i;
 			}
 			lenValue = i - iValue;
 		}
-		if(i+1 > npb->strLen || npb->str[i] != ';')
+
+		if(i+1 > npb->strLen || (npb->str[i] != ';' && npb->str[i] != data->terminator))
 			FAIL(LN_WRONGPARSER);
-		++i; /* skip ';' */
+
+		if(npb->str[i] == ';')
+			++i; /* skip ';' */
+
 		if(value != NULL) {
 			CHKN(name = malloc(sizeof(char) * (lenName + 1)));
 			memcpy(name, npb->str+iName, lenName);


### PR DESCRIPTION
As of today, Checkpoint logs do not necessarily provide a semicolon
between the last key:value pair and the terminator.
This causes the parse to fail with current behavior.