### PR TITLE
String type fix : Fix segmentationFault for >= 0x80 characters

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3518,7 +3518,7 @@ struct data_String {
 	char perm_chars[256]; // TODO: make this bit-wise, so we need  only 32 bytes
 };
 static inline void
-stringSetPermittedChar(struct data_String *const data, char c, int val)
+stringSetPermittedChar(struct data_String *const data, unsigned char c, int val)
 {
 #if 0
 	const int i = (unsigned) c / 8;
@@ -3526,12 +3526,12 @@ stringSetPermittedChar(struct data_String *const data, char c, int val)
 	const unsigned mask = ~(1 << shft);
 	perm_arr[i] = (perm_arr[i] & (0xff
 #endif
-	data->perm_chars[(unsigned)c] = val;
+	data->perm_chars[c] = val;
 }
 static inline int
-stringIsPermittedChar(struct data_String *const data, char c)
+stringIsPermittedChar(struct data_String *const data, unsigned char c)
 {
-	return data->perm_chars[(unsigned)c];
+	return data->perm_chars[c];
 }
 static void
 stringAddPermittedCharArr(struct data_String *const data,
@@ -3539,7 +3539,7 @@ stringAddPermittedCharArr(struct data_String *const data,
 {
 	const size_t nchars = strlen(optval);
 	for(size_t i = 0 ; i < nchars ; ++i) {
-		stringSetPermittedChar(data, optval[i], 1);
+		stringSetPermittedChar(data, (unsigned char)optval[i], 1);
 	}
 }
 static void
@@ -3548,8 +3548,8 @@ stringAddPermittedFromTo(struct data_String *const data,
 	const unsigned char to)
 {
 	assert(from <= to);
-	for(size_t i = from ; i <= to ; ++i) {
-		stringSetPermittedChar(data, (char) i, 1);
+	for(unsigned char i = from ; i <= to ; ++i) {
+		stringSetPermittedChar(data, i, 1);
 	}
 }
 static inline void
@@ -3658,7 +3658,7 @@ PARSER_Parse(String)
 		/* terminating conditions */
 		if(!bHaveQuotes && npb->str[i] == ' ')
 			break;
-		if(!stringIsPermittedChar(data, npb->str[i]))
+		if(!stringIsPermittedChar(data, (unsigned char)npb->str[i]))
 			break;
 		i++;
 	}

--- a/tests/field_string.sh
+++ b/tests/field_string.sh
@@ -25,6 +25,9 @@ assert_output_json_eq '{ "f": "test with \" double escape" }'
 execute 'a "test with \" backslash escape" b'
 assert_output_json_eq '{ "f": "test with \" backslash escape" }'
 
+execute 'a "test with bœuf unicode" b'
+assert_output_json_eq '{ "f": "test with bœuf unicode" }'
+
 echo test quoting.mode
 reset_rules
 add_rule 'version=2'


### PR DESCRIPTION
### Actual behavior
Actually, when using the following rulebase : 
```
version=2
rule=:%test:string%
```
And the following line to parse : 
```
$ echo 'Lebœufpa' | hexdump -C
00000000  4c 65 62 c5 93 75 66 70  61 0a                    |Leb..ufpa.|
0000000a
```

I get the following error : 
```sh
$ echo 'Lebœufpa' | ./lognormalizer -r test.rb
Erreur de segmentation (core dumped)
```

### Analysis

This **segmentation fault (core dumped)** occurs because of the byte "\xc5".
Indeed, the type "string" is mainly handled with the following function, that is called for each character to parse : 
```c  
static inline int
stringIsPermittedChar(struct data_String *const data, char c)
{
	return data->perm_chars[(unsigned)c];
}
```
And the table **perm_chars** has the following definition : 
```c  
	char perm_chars[256];
```

So, when the character "\xc5", which is negative when defined as a *signed char* is casted as *unsigned int*, it gives the following : 
`(signed char)0xc5 == (unsigned int)0xffffffc5`

Finally, the function *stringIsPermittedChar* which tries to find the value of 0xffffffc5 in the table `perm_chars` which is 256 long, the program crashes. 

Furthermore, this bug actually happens for any character >= 0x80. That is to say for any character negative when signed char.

### Fix

To fix this error, each caracter must be handled with an **unsigned char** type.
Indeed, the indexes allowed by **perm_chars** table goes from 0 to 255.

### Fixed behavior

After fixing, when using the rule and line listed above, the error does not raise and the parsing behavior is as expected.
```sh
$ echo 'Lebœufpa' | ./lognormalizer -r test.rb
{ "test": "Lebœufpa" }
```


