### PR TITLE
fix memory leak when a custom type in rules does not match

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1443,6 +1443,10 @@ tryParser(npb_t *const __restrict__ npb,
 		LN_DBGPRINTF(dag->ctx, "called CUSTOM PARSER '%s', result %d, "
 			"offs %zd, *pParsed %zd", dag->ctx->type_pdags[prs->custTypeIdx].name, r, *offs, *pParsed);
 		*pParsed = npb->parsedTo - *offs;
+		if (r != 0) {
+			json_object_put(*value);
+			*value = NULL;
+		}
 		#ifdef	ADVANCED_STATS
 		es_addBuf(&npb->astats.exec_path, hdr, lenhdr);
 		es_addBuf(&npb->astats.exec_path, "[R:USR],", 8);


### PR DESCRIPTION
### Original Pull-Request 
https://github.com/rsyslog/liblognorm/pull/343
Found and closes a memory leak when user-defined types return without a match.
Closes https://github.com/rsyslog/liblognorm/issues/223

